### PR TITLE
v0.1.1: Now support CMake FetchContents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,21 +9,28 @@ configure_file(
     @ONLY
 )
 
-include_directories(include)
-
 set(SOURCES
     src/CLIEngine_core.cpp
 )
 
 add_library(cli_engine ${SOURCES})
-target_include_directories(cli_engine PUBLIC include)
+target_include_directories(cli_engine
+    PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+add_library(CLIEngine::CLIEngine ALIAS cli_engine)
 
 # samples
-add_executable(hello_CLIEngine src/samples/hello_CLIEngine.cpp)
-target_link_libraries(hello_CLIEngine PRIVATE cli_engine)
+option(BUILD_SAMPLES "Build sample executables" ON)
+if(BUILD_SAMPLES)
+    add_executable(hello_CLIEngine src/samples/hello_CLIEngine.cpp)
+    target_link_libraries(hello_CLIEngine PRIVATE cli_engine)
 
-add_executable(sprite_smile_face src/samples/sprite_smile_face.cpp)
-target_link_libraries(sprite_smile_face PRIVATE cli_engine)
+    add_executable(sprite_smile_face src/samples/sprite_smile_face.cpp)
+    target_link_libraries(sprite_smile_face PRIVATE cli_engine)
 
-add_executable(sprite_CLIEngine src/samples/sprite_CLIEngine.cpp)
-target_link_libraries(sprite_CLIEngine PRIVATE cli_engine)
+    add_executable(sprite_CLIEngine src/samples/sprite_CLIEngine.cpp)
+    target_link_libraries(sprite_CLIEngine PRIVATE cli_engine)
+endif()


### PR DESCRIPTION
If you want to use `CLIEngine` in your (local) project:

# `CMakeLists.txt`
```cmake
cmake_minimum_required(VERSION 3.22)
set(CMAKE_CXX_STANDARD 11)

project(MyProject LANGUAGES CXX)

include(FetchContent)
FetchContent_Declare(CLIEngine
    GIT_REPOSITORY https://github.com/Ootzk/CLIEngine.git
    GIT_TAG v0.1.1
    GIT_PROGRESS TRUE
    GIT_SHALLOW TRUE
)
FetchContent_MakeAvailable(CLIEngine)

set(SOURCES
    main.cpp
)

add_executable(myproject ${SOURCES})
target_include_directories(myproject PRIVATE ${CLIEngine_SOURCE_DIR}/include)
target_link_libraries(myproject PRIVATE cli_engine)  # cli_engine is alias defined in CLIEngine
```

# `main.cpp`
```cpp
#include "CLIEngine_core.hpp"

int main()
{
    CLIEngine::setPalette(CLIEngine::Color::RED, CLIEngine::Color::WHITE);
    std::cout << "hello world" << x << endl;
    CLIEngine::setPalette();

    // for more examples, refer wiki.
}
```