### PR TITLE
v0.2.0: Introduce `Screen`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 set(CMAKE_CXX_STANDARD 17)
 
-project(CLIEngine VERSION 0.1.0 LANGUAGES CXX)
+project(CLIEngine VERSION 0.2.0 LANGUAGES CXX)
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/include/version.hpp.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 project(CLIEngine VERSION 0.1.0 LANGUAGES CXX)
 
@@ -11,6 +11,7 @@ configure_file(
 
 set(SOURCES
     src/CLIEngine_core.cpp
+    src/CLIEngine_screen.cpp
 )
 
 add_library(cli_engine ${SOURCES})
@@ -33,4 +34,7 @@ if(BUILD_SAMPLES)
 
     add_executable(sprite_CLIEngine src/samples/sprite_CLIEngine.cpp)
     target_link_libraries(sprite_CLIEngine PRIVATE cli_engine)
+
+    add_executable(screen_transition src/samples/screen_transition.cpp)
+    target_link_libraries(screen_transition PRIVATE cli_engine)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,4 +37,7 @@ if(BUILD_SAMPLES)
 
     add_executable(screen_transition src/samples/screen_transition.cpp)
     target_link_libraries(screen_transition PRIVATE cli_engine)
+
+    add_executable(colors src/samples/colors.cpp)
+    target_link_libraries(colors PRIVATE cli_engine)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CLI Engine
 
-![Version](https://img.shields.io/badge/Version-v0.1.0-blue)
+![Version](https://img.shields.io/badge/Version-v0.2.0-blue)
 
 > Simple game engine that targets on CLI interface.
 
@@ -11,3 +11,7 @@
 | Windows | ✔️ |
 | Linux | ❌ |
 | macOS | ❌ |
+
+## How to use?
+
+Please Refer [CLIEngine Wiki!](https://github.com/Ootzk/CLIEngine/wiki)

--- a/include/CLIEngine_core.hpp
+++ b/include/CLIEngine_core.hpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <optional>
 #include <random>
 #include <string>
@@ -86,6 +87,7 @@ enum class Color
 
 	DEFAULT      // ' ' (WHITE in foreground, BLACK in background)
 };
+Color char2Color(char c);
 
 void setPalette(Color foreground = Color::WHITE, Color background = Color::BLACK);
 
@@ -95,9 +97,6 @@ private:
 	std::vector<std::string> text;
 	std::vector<std::string> font;
 	std::vector<std::string> back;
-
-private:
-	static Color char2Color(char c);
 
 public:
 	Sprite(const std::vector<std::string>&, const std::vector<std::string>&, const std::vector<std::string>&);

--- a/include/CLIEngine_screen.hpp
+++ b/include/CLIEngine_screen.hpp
@@ -1,0 +1,39 @@
+#include "CLIEngine_core.hpp"
+
+namespace CLIEngine {
+
+struct ScreenTransition; // forward declaration
+
+class Screen : public std::enable_shared_from_this<Screen>
+{
+protected:
+    static void clear();
+    static void wait();
+
+// handle input
+    virtual std::optional<std::shared_ptr<Screen>> input() = 0;
+
+// state machine pattern
+    virtual void enter(const ScreenTransition&) = 0;
+    virtual void exit(const ScreenTransition&) = 0;
+    
+    virtual void draw() = 0;
+
+    virtual std::optional<ScreenTransition> update() = 0;
+
+public:
+    const std::string name;
+    ScreenTransition loop(const ScreenTransition&);
+
+    Screen(const std::string&);
+};
+
+struct ScreenTransition
+{
+    std::shared_ptr<Screen> from;
+    std::shared_ptr<Screen> to;
+
+    std::string message;
+};
+
+}  // end of CLIEngine namespace

--- a/src/CLIEngine_core.cpp
+++ b/src/CLIEngine_core.cpp
@@ -110,7 +110,7 @@ Sprite::Sprite(
 	this->back = back;
 }
 
-Color Sprite::char2Color(char c)
+Color char2Color(char c)
 {
 	switch (c)
 	{

--- a/src/CLIEngine_screen.cpp
+++ b/src/CLIEngine_screen.cpp
@@ -1,0 +1,33 @@
+#include "CLIEngine_screen.hpp"
+
+namespace CLIEngine {
+
+Screen::Screen(const std::string& name) : name(name)
+{
+}
+
+void Screen::clear()
+{
+    system("cls");
+}
+
+void Screen::wait()
+{
+    Sleep(1000 / FPS);
+}
+
+ScreenTransition Screen::loop(const ScreenTransition& previous)
+{
+    this->enter(previous);
+
+    std::optional<ScreenTransition> future = std::nullopt;
+    while (!future.has_value()) {
+        future = this->update();
+    }
+
+    this->exit(future.value());
+
+    return future.value();
+}
+
+} // end of CLIEngine namespace

--- a/src/samples/colors.cpp
+++ b/src/samples/colors.cpp
@@ -1,0 +1,123 @@
+#include "CLIEngine_core.hpp"
+
+int main()
+{
+    CLIEngine::Sprite font_colors{
+        {
+            "BLACK",
+            "BLUE",
+            "GREEN",
+            "CYAN",
+            "RED",
+            "PURPLE",
+            "BROWN",
+            "LIGHTGRAY",
+            "DARKGRAY",
+            "LIGHTBLUE",
+            "LIGHTGREEN",
+            "LIGHTCYAN",
+            "LIGHTRED",
+            "LIGHTPURPLE",
+            "YELLOW",
+            "WHITE"
+        },
+        {
+            "XXXXX",
+            "BBBB",
+            "GGGGG",
+            "CCCC",
+            "RRR",
+            "PPPPPP",
+            "OOOOO",
+            "aaaaaaaaa",
+            "AAAAAAAA",
+            "bbbbbbbbb",
+            "gggggggggg",
+            "ccccccccc",
+            "rrrrrrrr",
+            "ppppppppppp",
+            "YYYYYY",
+            "WWWWW"
+        },
+        {
+            "WWWWW", // cuz black font will not shown in black background;
+            "    ",
+            "     ",
+            "    ",
+            "   ",
+            "      ",
+            "     ",
+            "         ",
+            "        ",
+            "         ",
+            "          ",
+            "         ",
+            "        ",
+            "           ",
+            "      ",
+            "     "
+        },
+    };
+
+    CLIEngine::Sprite background_colors{
+        {
+            "BLACK",
+            "BLUE",
+            "GREEN",
+            "CYAN",
+            "RED",
+            "PURPLE",
+            "BROWN",
+            "LIGHTGRAY",
+            "DARKGRAY",
+            "LIGHTBLUE",
+            "LIGHTGREEN",
+            "LIGHTCYAN",
+            "LIGHTRED",
+            "LIGHTPURPLE",
+            "YELLOW",
+            "WHITE"
+        },
+        {
+            "     ",
+            "    ",
+            "     ",
+            "    ",
+            "   ",
+            "      ",
+            "     ",
+            "         ",
+            "        ",
+            "         ",
+            "          ",
+            "         ",
+            "        ",
+            "           ",
+            "      ",
+            "XXXXX"  // cuz white font will not shown in white background;
+        },
+        {
+            "XXXXX",
+            "BBBB",
+            "GGGGG",
+            "CCCC",
+            "RRR",
+            "PPPPPP",
+            "OOOOO",
+            "aaaaaaaaa",
+            "AAAAAAAA",
+            "bbbbbbbbb",
+            "gggggggggg",
+            "ccccccccc",
+            "rrrrrrrr",
+            "ppppppppppp",
+            "YYYYYY",
+            "WWWWW"
+        }
+    };
+
+    while (true) {
+        font_colors.draw();
+        background_colors.draw({16, 0});
+    }
+}

--- a/src/samples/screen_transition.cpp
+++ b/src/samples/screen_transition.cpp
@@ -1,0 +1,211 @@
+#include "CLIEngine_core.hpp"
+#include "CLIEngine_screen.hpp"
+
+using ScreenPtr = std::shared_ptr<CLIEngine::Screen>;
+
+class Screen_Char : public CLIEngine::Screen
+{
+private:
+    CLIEngine::Sprite sprite;
+    char message_color;
+    ScreenPtr left;
+    ScreenPtr right;
+
+public:
+    Screen_Char(
+        const std::string& name,
+        CLIEngine::Sprite sprite,
+        char message_color
+    ): sprite(sprite), message_color(message_color), CLIEngine::Screen{name}
+    {
+
+    }
+
+    void init(ScreenPtr left, ScreenPtr right)
+    {
+        this->left = left;
+        this->right = right;
+    }
+
+protected:
+    std::optional<std::shared_ptr<Screen>> input() override
+    {
+        switch (CLIEngine::getKey())
+        {
+        case CLIEngine::Key::LEFT: { return left; }
+        case CLIEngine::Key::RIGHT: { return right; }
+        default: { return std::nullopt; }
+        }
+    }
+
+    void enter(const CLIEngine::ScreenTransition& previous) override
+    {
+        clear();
+        this->sprite.draw();
+
+        CLIEngine::moveCursor();
+        CLIEngine::setPalette(CLIEngine::char2Color(this->message_color));
+        std::cout << previous.message;
+        CLIEngine::setPalette();
+    }
+
+    void exit(const CLIEngine::ScreenTransition& future) override
+    {
+        // do nothing
+    }
+
+    void draw() override
+    {
+        // do nothing because everything drawn in enter step
+    }
+
+    std::optional<CLIEngine::ScreenTransition> update() override
+    {
+        std::optional<ScreenPtr> future = this->input();
+        this->draw();
+        this->wait();
+
+        if (future.has_value()) {
+            return CLIEngine::ScreenTransition{
+                shared_from_this(),
+                future.value(),
+                "transited from " + this->name + " to " + future.value()->name
+            };
+        }
+        return std::nullopt;
+    }
+};
+
+int main()
+{
+    CLIEngine::Sprite spriteC{
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "<-                        ->",
+            " I                        L ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "GG                        BB",
+            " G                        B ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "    RRRRRRRRRRRRRRRRRRRR    ",
+            "    RR                RR    ",
+            "    R    RRRRRRRRRRR   R    ",
+            "    R   RRRRRRRRRRRRRRRR    ",
+            "    R   RRRRRRRRRRRRRRRR    ",
+            "    R   RRRRRRRRRRRRRRRR    ",
+            "    R    RRRRRRRRRRR   R    ",
+            "    RR                RR    ",
+            "    RRRRRRRRRRRRRRRRRRRR    ",
+        }
+    };
+    CLIEngine::Sprite spriteL{
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "<-                        ->",
+            " C                        I ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "RR                        GG",
+            " R                        G ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "    BBBBBBBBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB    BBBBBBBBBBBBBB    ",
+            "    BB                BB    ",
+            "    BBBBBBBBBBBBBBBBBBBB    ",
+        }
+    };
+    CLIEngine::Sprite spriteI{
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "<-                        ->",
+            " L                        C ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "BB                        RR",
+            " B                        R ",
+            "                            ",
+            "                            ",
+            "                            ",
+            "                            "
+        },
+        {
+            "                            ",
+            "    GGGGGGGGGGGGGGGGGGGG    ",
+            "    GGG              GGG    ",
+            "    GGGGGGGG    GGGGGGGG    ",
+            "    GGGGGGGG    GGGGGGGG    ",
+            "    GGGGGGGG    GGGGGGGG    ",
+            "    GGGGGGGG    GGGGGGGG    ",
+            "    GGGGGGGG    GGGGGGGG    ",
+            "    GGG              GGG    ",
+            "    GGGGGGGGGGGGGGGGGGGG    ",
+        }
+    };
+
+    auto C = std::make_shared<Screen_Char>("Screen_C", spriteC, 'R');
+    auto L = std::make_shared<Screen_Char>("Screen_L", spriteL, 'B');
+    auto I = std::make_shared<Screen_Char>("Screen_I", spriteI, 'G');
+
+    C->init(I, L);
+    L->init(C, I);
+    I->init(L, C);
+
+    ScreenPtr current = C;
+    CLIEngine::ScreenTransition msg = { current, current, {} };
+    while (true) {
+        msg = current->loop(msg);
+        current = msg.to;
+    }
+    return 0;
+}


### PR DESCRIPTION
`Screen` is a state object which manages the entire lifecycle of a specific terminal screen.
For more detailed usage, please refer [CLIEngine wiki](https://github.com/Ootzk/CLIEngine/wiki)

Also, CLIEngine requires c++ standard 17 (v0.1.0~ requires 11)